### PR TITLE
Custom executor

### DIFF
--- a/lib/customValidators.js
+++ b/lib/customValidators.js
@@ -1,5 +1,4 @@
 const {
-    Selection,
     GraphQLError,
 } = require('graphql');
 
@@ -14,7 +13,7 @@ exports.subscriptionHasSingleRootField = context => {
                     if (selection.kind === 'Field') {
                         numFields++;
                     } else {
-                        context.reportError(new GraphQLError('Subscriptions do not support fragments on the root field', [
+                        context.reportError(new GraphQLError('Subscriptions do not support fragments on the root field.', [
                             node
                         ]));
                     }

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,32 +1,37 @@
 const _ = require('lodash');
 const md5 = require('md5');
-const lazyExecutor = require('smallorange-graphql-lazy-executor');
 const {
 	Observable,
 	Subject
 } = require('rxjs');
 const {
+	GraphQLError,
+	buildSchema,
+	execute,
+	parse,
+	specifiedRules,
+	validate
+} = require('graphql');
+const {
 	getArgumentValues
 } = require('graphql/execution/values');
-const {
-	parse
-} = require('graphql/language');
 
 const {
 	subscriptionHasSingleRootField
 } = require('./customValidators');
 
 module.exports = class Subscriptions {
-	constructor(schema, concurrency = Number.MAX_SAFE_INTEGER) {
+	constructor(schema, events = {}, executor = null, concurrency = Number.MAX_SAFE_INTEGER) {
 		if (!schema) {
-			throw new Error('No GraphQL schema provided');
+			throw new Error('No GraphQL schema provided.');
 		}
 
-		this.schema = schema;
+		this.schema = _.isString(schema) ? buildSchema(schema) : schema;
+		this.events = events;
+		this.executor = this.setExecutor(executor);
 		this.concurrency = concurrency;
 		this.subscriptions = {};
 		this.subscribedSymbol = Symbol();
-
 		this.inbound = new Subject();
 		this.stream = this.inbound
 			.filter(({
@@ -74,6 +79,23 @@ module.exports = class Subscriptions {
 			.share();
 	}
 
+	setExecutor(executor = null) {
+		if (!executor || !_.isFunction(executor)) {
+			try {
+				return (...args) => Observable.fromPromise(execute.apply(null, args))
+					.do(response => {
+						if (response.errors) {
+							throw new Error(response.errors.join());
+						}
+					});
+			} catch (err) {
+				return Observable.throw(err);
+			}
+		}
+
+		return executor;
+	}
+
 	run(namespace, event, root = {}, context = {}) {
 		this.inbound.next({
 			event,
@@ -89,27 +111,33 @@ module.exports = class Subscriptions {
 		}
 
 		if (!_.isObject(subscriber)) {
-			throw new Error('Subscriber must be an object.');
+			throw new GraphQLError('Subscriber must be an object.');
 		}
 
 		if (!_.isPlainObject(context)) {
-			throw new Error('context should be a plain object.');
+			throw new GraphQLError('context should be a plain object.');
 		}
 
-		const executor = lazyExecutor(this.schema, query, [
-			subscriptionHasSingleRootField
-		]);
+		const parsedQuery = parse(query);
+		const errors = validate(
+			this.schema,
+			parsedQuery,
+			specifiedRules.concat(subscriptionHasSingleRootField)
+		);
 
-		const [
-			data
-		] = this.extractQueryData(this.schema, executor.parsedQuery, variables);
+		if (errors.length) {
+			throw new GraphQLError(errors);
+		}
+
+		const data = this.getQueryData(this.schema, parsedQuery, variables);
 
 		const {
 			args,
 			events,
+			kind,
 			operationName,
 			rootName
-		} = data;
+		} = data[0];
 
 		const hash = md5(`${query}${JSON.stringify(args)}${JSON.stringify(context)}`);
 
@@ -130,7 +158,14 @@ module.exports = class Subscriptions {
 								context = _.extend(context, extendContext);
 							}
 
-							return executor(root, context, variables, operationName)
+							return this.executor(
+									this.schema,
+									parsedQuery,
+									root,
+									context,
+									variables,
+									operationName
+								)
 								.map(query => ({
 									args,
 									context,
@@ -168,7 +203,7 @@ module.exports = class Subscriptions {
 		}
 
 		if (!_.isObject(subscriber)) {
-			throw new Error('Subscriber must be an object');
+			throw new GraphQLError('Subscriber must be an object.');
 		}
 
 		const subscriberSubscriptions = _.get(subscriber, this.subscribedSymbol);
@@ -198,12 +233,8 @@ module.exports = class Subscriptions {
 		return true;
 	}
 
-	extractQueryData(schema, query, variables = {}) {
-		if (_.isString(query)) {
-			query = parse(query);
-		}
-
-		return query.definitions
+	getQueryData(schema, parsedQuery, variables = {}) {
+		return parsedQuery.definitions
 			.reduce((reduction, definition) => {
 				if (definition.kind === 'OperationDefinition') {
 					const rootFields = definition.selectionSet.selections;
@@ -217,7 +248,7 @@ module.exports = class Subscriptions {
 					const fields = subcription
 						.getFields();
 
-					return rootFields.map(rootField => {
+					reduction = rootFields.map(rootField => {
 						const {
 							alias,
 							name
@@ -225,8 +256,8 @@ module.exports = class Subscriptions {
 
 						const rootAlias = alias ? alias.value : null;
 						const rootName = name.value;
-						const args = getArgumentValues(fields[rootName], rootField, variables);
-						const events = fields[rootName].events || {};
+						const args = fields[rootName] ? getArgumentValues(fields[rootName], rootField, variables) : {};
+						const events = _.get(this.events, rootName, {});
 
 						return {
 							args,
@@ -237,6 +268,8 @@ module.exports = class Subscriptions {
 						};
 					});
 				}
+
+				return reduction;
 			}, null);
 	}
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -44,9 +44,9 @@ module.exports = class Subscriptions {
 				root,
 				event
 			}) => {
-				const queries = _.get(this.subscriptions, `${namespace}.${event}`, {});
+				const subscriptions = _.get(this.subscriptions, `${namespace}.${event}`, {});
 
-				return Observable.pairs(queries)
+				return Observable.pairs(subscriptions)
 					.mergeMap(([
 						hash, {
 							executor,
@@ -58,7 +58,7 @@ module.exports = class Subscriptions {
 								args,
 								context,
 								operationName,
-								query,
+								response,
 								rootName,
 								variables
 							}) => ({
@@ -68,7 +68,7 @@ module.exports = class Subscriptions {
 								hash,
 								namespace,
 								operationName,
-								query,
+								response,
 								root,
 								rootName,
 								subscribers,
@@ -105,8 +105,8 @@ module.exports = class Subscriptions {
 		});
 	}
 
-	subscribe(subscriber, query, variables = {}, context = {}) {
-		if (!subscriber || !query) {
+	subscribe(subscriber, subscription, variables = {}, context = {}) {
+		if (!subscriber || !subscription) {
 			return;
 		}
 
@@ -118,10 +118,10 @@ module.exports = class Subscriptions {
 			throw new GraphQLError('context should be a plain object.');
 		}
 
-		const parsedQuery = parse(query);
+		const ast = parse(subscription);
 		const errors = validate(
 			this.schema,
-			parsedQuery,
+			ast,
 			specifiedRules.concat(subscriptionHasSingleRootField)
 		);
 
@@ -129,17 +129,16 @@ module.exports = class Subscriptions {
 			throw new GraphQLError(errors);
 		}
 
-		const data = this.getQueryData(this.schema, parsedQuery, variables);
-
+		const astData = this.getAstData(this.schema, ast, variables);
 		const {
 			args,
 			events,
 			kind,
 			operationName,
 			rootName
-		} = data[0];
+		} = astData[0];
 
-		const hash = md5(`${query}${JSON.stringify(args)}${JSON.stringify(context)}`);
+		const hash = md5(`${subscription}${JSON.stringify(args)}${JSON.stringify(context)}`);
 
 		return _.flatMap(events, (events, namespace) => {
 			if (!_.isArray(events)) {
@@ -160,17 +159,17 @@ module.exports = class Subscriptions {
 
 							return this.executor(
 									this.schema,
-									parsedQuery,
+									ast,
 									root,
 									context,
 									variables,
 									operationName
 								)
-								.map(query => ({
+								.map(response => ({
 									args,
 									context,
 									operationName,
-									query,
+									response,
 									rootName,
 									variables
 								}));
@@ -233,8 +232,8 @@ module.exports = class Subscriptions {
 		return true;
 	}
 
-	getQueryData(schema, parsedQuery, variables = {}) {
-		return parsedQuery.definitions
+	getAstData(schema, ast, variables = {}) {
+		return ast.definitions
 			.reduce((reduction, definition) => {
 				if (definition.kind === 'OperationDefinition') {
 					const rootFields = definition.selectionSet.selections;

--- a/package.json
+++ b/package.json
@@ -14,8 +14,7 @@
     "graphql": "^0.9.3",
     "lodash": "^4.17.4",
     "md5": "^2.2.1",
-    "rxjs": "^5.3.0",
-    "smallorange-graphql-lazy-executor": "^1.0.8"
+    "rxjs": "^5.3.0"
   },
   "devDependencies": {
     "chai": "^3.5.0",

--- a/spec/index.spec.js
+++ b/spec/index.spec.js
@@ -2,13 +2,17 @@ const _ = require('lodash');
 const chai = require('chai');
 const sinon = require('sinon');
 const sinonChai = require('sinon-chai');
-const lazyExecutor = require('smallorange-graphql-lazy-executor');
 const {
     Observable
 } = require('rxjs');
+const {
+    parse,
+    printSchema
+} = require('graphql');
 
 const {
     event,
+    events,
     namespace,
     queries,
     schema,
@@ -20,19 +24,32 @@ chai.use(sinonChai);
 
 const expect = chai.expect;
 
-describe('index.js', () => {
+describe.only('index.js', () => {
     let subscriptions;
 
     beforeEach(() => {
-        subscriptions = new Subscriptions(schema);
+        subscriptions = new Subscriptions(schema, events);
     });
 
     describe('constructor', () => {
+        beforeEach(() => {
+           sinon.spy(Subscriptions.prototype, 'setExecutor'); 
+        });
+
+        afterEach(() => {
+           Subscriptions.prototype.setExecutor.restore();
+        });
+
         it('should throw if no schema', () => {
-            expect(() => new Subscriptions()).to.throw('No GraphQL schema provided');
+            expect(() => new Subscriptions()).to.throw('No GraphQL schema provided.');
         });
 
         it('should feed schema', () => {
+            expect(subscriptions.schema).to.be.an('object');
+        });
+
+        it('should parse schema if string provided', () => {
+            subscriptions = new Subscriptions(printSchema(schema));
             expect(subscriptions.schema).to.be.an('object');
         });
 
@@ -40,8 +57,16 @@ describe('index.js', () => {
             expect(subscriptions.concurrency).to.equal(Number.MAX_SAFE_INTEGER);
         });
 
+        it('should feed custom executor', () => {
+            const executor = () => null;
+            subscriptions = new Subscriptions(schema, events, executor, 4);
+            
+            expect(Subscriptions.prototype.setExecutor).to.have.been.calledWith(executor);
+            expect(subscriptions.executor).to.equal(executor);
+        });
+
         it('should feed custom concurrency', () => {
-            subscriptions = new Subscriptions(schema, 4);
+            subscriptions = new Subscriptions(schema, events, null, 4);
             expect(subscriptions.concurrency).to.equal(4);
         });
 
@@ -397,6 +422,23 @@ describe('index.js', () => {
         });
     });
 
+    describe('setExecutor', () => {
+        it('should return default executor', () => {
+           expect(subscriptions.setExecutor()).to.be.a('function'); 
+        });
+
+        it('should return default executor if no function provided', () => {
+
+           expect(subscriptions.setExecutor('string')).to.be.a('function'); 
+        });
+
+        it('should return custom executor if function provided', () => {
+            const executor = () => null;
+
+           expect(subscriptions.setExecutor(executor)).to.equal(executor); 
+        });
+    });
+
     describe('run', () => {
         beforeEach(() => {
             sinon.spy(subscriptions.inbound, 'next');
@@ -438,22 +480,22 @@ describe('index.js', () => {
 
     describe('subscribe', () => {
         beforeEach(() => {
-            sinon.spy(subscriptions, 'extractQueryData');
+            sinon.spy(subscriptions, 'getQueryData');
         });
 
         afterEach(() => {
-            subscriptions.extractQueryData.restore();
+            subscriptions.getQueryData.restore();
         });
 
         it('should do nothing if no subscriber', () => {
             expect(subscriptions.subscribe()).to.be.undefined;
-            expect(subscriptions.extractQueryData)
+            expect(subscriptions.getQueryData)
                 .not.to.have.been.called;
         });
 
         it('should do nothing if no query', () => {
             expect(subscriptions.subscribe({})).to.be.undefined;
-            expect(subscriptions.extractQueryData)
+            expect(subscriptions.getQueryData)
                 .not.to.have.been.called;
         });
 
@@ -480,7 +522,7 @@ describe('index.js', () => {
                         name
                     }
                 }
-            `)).to.throw('GraphQLError: Subscriptions do not support fragments on the root field');
+            `)).to.throw('GraphQLError: Subscriptions do not support fragments on the root field.');
         });
 
         it('should return hashes based on query, variables and context', () => {
@@ -735,35 +777,11 @@ describe('index.js', () => {
         });
     });
 
-    describe('extractQueryData', () => {
+    describe('getQueryData', () => {
         it('should extract query data from parsed query', () => {
-            const executor = lazyExecutor(schema, queries[0]);
+            const parsedQuery = parse(queries[0]);
 
-            expect(subscriptions.extractQueryData(schema, executor.parsedQuery, {
-                name: 'Rohde',
-                age: 20,
-                city: 'San Francisco',
-                unknownVariable: null
-            })).to.deep.equal([{
-                args: {
-                    name: 'Rohde',
-                    age: 20,
-                    city: 'San Francisco'
-                },
-                events: {
-                    namespace: [
-                        'event',
-                        'anotherEvent'
-                    ]
-                },
-                operationName: 'changeUser',
-                rootAlias: null,
-                rootName: 'user'
-            }]);
-        });
-
-        it('should extract query data from string query', () => {
-            expect(subscriptions.extractQueryData(schema, queries[0], {
+            expect(subscriptions.getQueryData(schema, parsedQuery, {
                 name: 'Rohde',
                 age: 20,
                 city: 'San Francisco',
@@ -787,9 +805,9 @@ describe('index.js', () => {
         });
 
         it('should return null if no subscription event', () => {
-            const executor = lazyExecutor(noSubscriptionSchema, queries[0]);
+            const parsedQuery = parse(queries[0]);
 
-            expect(subscriptions.extractQueryData(noSubscriptionSchema, executor.parsedQuery, {
+            expect(subscriptions.getQueryData(noSubscriptionSchema, parsedQuery, {
                 name: 'Rohde',
                 age: 20,
                 city: 'San Francisco',

--- a/spec/index.spec.js
+++ b/spec/index.spec.js
@@ -247,7 +247,7 @@ describe.only('index.js', () => {
                             hash: '69ad83b324531f979aca7a56cc32047c',
                             namespace: 'namespace',
                             operationName: 'changeUser',
-                            query: {
+                            response: {
                                 data: {
                                     user: {
                                         age: 20,
@@ -279,7 +279,7 @@ describe.only('index.js', () => {
                             hash: '84e15e7de349e804f7ec7db0dfe91c03',
                             namespace: 'namespace',
                             operationName: null,
-                            query: {
+                            response: {
                                 data: {
                                     user: {
                                         age: 20,
@@ -311,7 +311,7 @@ describe.only('index.js', () => {
                             hash: '4c5db9f456b132e72f77939b2d322796',
                             namespace: 'namespace',
                             operationName: null,
-                            query: {
+                            response: {
                                 data: {
                                     userWithSingleEvent: {
                                         age: 20,
@@ -343,7 +343,7 @@ describe.only('index.js', () => {
                             hash: '69ad83b324531f979aca7a56cc32047c',
                             namespace: 'namespace',
                             operationName: 'changeUser',
-                            query: {
+                            response: {
                                 data: {
                                     user: {
                                         age: 20,
@@ -375,7 +375,7 @@ describe.only('index.js', () => {
                             hash: '84e15e7de349e804f7ec7db0dfe91c03',
                             namespace: 'namespace',
                             operationName: null,
-                            query: {
+                            response: {
                                 data: {
                                     user: {
                                         age: 20,
@@ -480,22 +480,22 @@ describe.only('index.js', () => {
 
     describe('subscribe', () => {
         beforeEach(() => {
-            sinon.spy(subscriptions, 'getQueryData');
+            sinon.spy(subscriptions, 'getAstData');
         });
 
         afterEach(() => {
-            subscriptions.getQueryData.restore();
+            subscriptions.getAstData.restore();
         });
 
         it('should do nothing if no subscriber', () => {
             expect(subscriptions.subscribe()).to.be.undefined;
-            expect(subscriptions.getQueryData)
+            expect(subscriptions.getAstData)
                 .not.to.have.been.called;
         });
 
         it('should do nothing if no query', () => {
             expect(subscriptions.subscribe({})).to.be.undefined;
-            expect(subscriptions.getQueryData)
+            expect(subscriptions.getAstData)
                 .not.to.have.been.called;
         });
 
@@ -777,11 +777,11 @@ describe.only('index.js', () => {
         });
     });
 
-    describe('getQueryData', () => {
+    describe('getAstData', () => {
         it('should extract query data from parsed query', () => {
             const parsedQuery = parse(queries[0]);
 
-            expect(subscriptions.getQueryData(schema, parsedQuery, {
+            expect(subscriptions.getAstData(schema, parsedQuery, {
                 name: 'Rohde',
                 age: 20,
                 city: 'San Francisco',
@@ -807,7 +807,7 @@ describe.only('index.js', () => {
         it('should return null if no subscription event', () => {
             const parsedQuery = parse(queries[0]);
 
-            expect(subscriptions.getQueryData(noSubscriptionSchema, parsedQuery, {
+            expect(subscriptions.getAstData(noSubscriptionSchema, parsedQuery, {
                 name: 'Rohde',
                 age: 20,
                 city: 'San Francisco',

--- a/testing/index.js
+++ b/testing/index.js
@@ -7,6 +7,19 @@ const {
 
 const event = 'event';
 const namespace = 'namespace';
+
+const events = {
+    user: {
+        namespace: [
+            'event',
+            'anotherEvent'
+        ]
+    },
+    userWithSingleEvent: {
+        namespace: 'event'
+    }
+};
+
 const queries = [
     `subscription changeUser($name: String!, $age: Int, $city: String) {
         user(name: $name, age: $age, city: $city) {
@@ -67,12 +80,6 @@ const schema = new GraphQLSchema({
         fields: {
             user: {
                 type: UserType,
-                events: {
-                    namespace: [
-                        'event',
-                        'anotherEvent'
-                    ]
-                },
                 args: {
                     age: {
                         type: GraphQLInt
@@ -90,9 +97,6 @@ const schema = new GraphQLSchema({
             },
             userWithSingleEvent: {
                 type: UserType,
-                events: {
-                    namespace: 'event'
-                },
                 args: {
                     age: {
                         type: GraphQLInt
@@ -142,6 +146,7 @@ const noSubscriptionSchema = new GraphQLSchema({
 
 module.exports = {
     event,
+    events,
     namespace,
     queries,
     schema,


### PR DESCRIPTION
This version is intended to add support to remote graphql executions in favor of micro services architectures;
It removes some dependencies to make it simple, also, events were removed from Subscription object to avoid possible future troubles and are passed as argument via constructor.